### PR TITLE
Add default destination for libuim output instead of /plugins

### DIFF
--- a/destdir.patch
+++ b/destdir.patch
@@ -1,0 +1,11 @@
+diff --git a/qt5/immodule/quimplatforminputcontextplugin.pro.in b/qt5/immodule/quimplatforminputcontextplugin.pro.in
+index 4696d12..6bdc888 100644
+--- a/qt5/immodule/quimplatforminputcontextplugin.pro.in
++++ b/qt5/immodule/quimplatforminputcontextplugin.pro.in
+@@ -38,5 +38,5 @@ SOURCES += @srcdir@/quimplatforminputcontext.cpp \
+ OTHER_FILES += uim.json
+ 
+ TARGET = uimplatforminputcontextplugin
+-
++DESTDIR = 
+ target.path += @DESTDIR@$$[QT_INSTALL_PLUGINS]/platforminputcontexts


### PR DESCRIPTION
Without `DESTDIR` , uim will use /plugins as output directory. Let set empty variable will make it use right output directory.
