### PR TITLE
Patching source code directly, fix destdir for qt5-lib output

### DIFF
--- a/qt5/immodule/quimplatforminputcontextplugin.pro.in
+++ b/qt5/immodule/quimplatforminputcontextplugin.pro.in
@@ -38,5 +38,5 @@ SOURCES += @srcdir@/quimplatforminputcontext.cpp \
 OTHER_FILES += uim.json
 
 TARGET = uimplatforminputcontextplugin
-
+DESTDIR = 
 target.path += @DESTDIR@$$[QT_INSTALL_PLUGINS]/platforminputcontexts


### PR DESCRIPTION
In commit 64480c4, we only created separate patch file. It requires patch file before using configure script. 
We just patched directly, it's better than using separate patch file.
