### PR TITLE
Add DESTDIR variable for qt5 inputcontext lib.

### DIFF
--- a/qt5/immodule/quimplatforminputcontextplugin.pro.in
+++ b/qt5/immodule/quimplatforminputcontextplugin.pro.in
@@ -38,5 +38,5 @@ SOURCES += @srcdir@/quimplatforminputcontext.cpp \
 OTHER_FILES += uim.json
 
 TARGET = uimplatforminputcontextplugin
-
+DESTDIR = 
 target.path += @DESTDIR@$$[QT_INSTALL_PLUGINS]/platforminputcontexts


### PR DESCRIPTION
Because DESTDIR variable's null, configure script will ignore qt5 lib path. We set it to empty variable can make it pass qt5 lib path.
